### PR TITLE
Enable socket.reuse_address in MDNS::Server so it plays nicely with other multicast clients

### DIFF
--- a/src/comms/server.cr
+++ b/src/comms/server.cr
@@ -7,6 +7,7 @@ class MDNS::Server
   # Usage: `MDNS::Server.new(MDNS::IPv4)`
   def initialize(@address : Socket::IPAddress, buffer_size = 16, loopback = false, hops = 255)
     @socket = UDPSocket.new @address.family
+    @socket.reuse_address = true
     @socket.reuse_port = true
     @socket.bind(@address.family.inet? ? Socket::IPAddress::UNSPECIFIED : Socket::IPAddress::UNSPECIFIED6, @address.port)
     @socket.join_group(@address)


### PR DESCRIPTION
I had to enable `@socket.reuse_address = true`. Otherwise I would get:

```crystal
Unhandled exception: Could not bind to '0.0.0.0:5353': Address in use (Socket::BindError)
```

presumably because I have other programs listening to port 5353, including `avahi-daemon` on my computer.

Per [this document](https://stackoverflow.com/questions/577885/what-are-the-use-cases-of-so-reuseaddr), "[with SO_REUSEADDR] every incoming multicast or broadcast UDP datagram destined to the shared port is delivered to all sockets bound to the port."

Works now! :smile: 